### PR TITLE
vmalloc changes in kernel 6.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,24 @@ else
 	PWD := $(shell pwd)
 
 default:
-	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
+	$(MAKE) -C $(KERNELDIR) M=$(PWD) CC=$(CC) CFLAGS='$(CFLAGS)' LDFLAGS='$(LDFLAGS)' modules
+
+install: default
+	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules_install
+	depmod -a
+
+live: install
+	modprobe eie_pro
+
+uninstall:
+	modprobe -r eie_pro
+	rm /lib/modules/$(shell uname -r)/updates/eie-pro.ko
+	depmod -a
 
 clean:
 	$(MAKE) -C $(KERNELDIR) M=$(PWD) clean
+
+cleanup: | uninstall clean
 
 test:
 	-sudo rmmod eie_pro
@@ -20,5 +34,5 @@ test:
 	-timeout 8 aplay -vv -Dsysdefault:CARD=pro /usr/share/sounds/alsa/Front_Center.wav
 
 check:
-	$(KERNELDIR)/scripts/checkpatch.pl --no-tree --file eie-pro.c
+	/lib/modules/$(shell uname -r)/source/scripts/checkpatch.pl --no-tree --file eie-pro.c
 endif


### PR DESCRIPTION
These are changes I've had to make to get the module working with 6.12 kernels onwards. 

I've added the version check conditional as this module is out of tree and so may be built by others on later kernels. However, running the checkpatch.pl script throws warnings with the version check, as expected.

I've added a few helper targets to the Makefile and fixed paths, these can be ignored if they don't apply to others.

I did the changes a few months ago and I think I copied the vmalloc changes from the same audio drive from which eie-pro was originally copied, however, I can't remember exactly which one at this moment in time.